### PR TITLE
[Chore] Swagger & Spring Security 설정 (#5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+
+### yml ###
+application.yml

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
+	//Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
 	//Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,6 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	//Spring Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,15 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	//Spring Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	//Test
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {

--- a/src/main/java/zighang2/zighang/global/config/SecurityConfig.java
+++ b/src/main/java/zighang2/zighang/global/config/SecurityConfig.java
@@ -18,15 +18,21 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception{
         http
-                .csrf(AbstractHttpConfigurer::disable)
+                .csrf(csrf -> csrf.ignoringRequestMatchers(
+                        "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/oauth2/**"
+                ))
                 .formLogin(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/","/login").permitAll()
+                        .requestMatchers("/", "/login", "/oauth2/**", "/error").permitAll()
+                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
                         .anyRequest().permitAll()
                 )
                 .logout(logout -> logout
                         .logoutUrl("/logout")
                         .logoutSuccessUrl("/login?logout")
+                        .logoutSuccessHandler(logoutSuccessHandler())
+                        .deleteCookies("JSESSIONID")
+                        .clearAuthentication(true)
                         .permitAll()
                 )
                 .oauth2Login(oauth -> oauth

--- a/src/main/java/zighang2/zighang/global/config/SecurityConfig.java
+++ b/src/main/java/zighang2/zighang/global/config/SecurityConfig.java
@@ -22,7 +22,7 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/","/login").permitAll()
-                        .anyRequest().authenticated()
+                        .anyRequest().permitAll()
                 )
                 .logout(logout -> logout
                         .logoutUrl("/logout")

--- a/src/main/java/zighang2/zighang/global/config/SecurityConfig.java
+++ b/src/main/java/zighang2/zighang/global/config/SecurityConfig.java
@@ -1,0 +1,49 @@
+package zighang2.zighang.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.logout.HttpStatusReturningLogoutSuccessHandler;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception{
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/","/login").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .logout(logout -> logout
+                        .logoutUrl("/logout")
+                        .logoutSuccessUrl("/login?logout")
+                        .permitAll()
+                )
+                .oauth2Login(oauth -> oauth
+                        .loginPage("/login")
+                        .defaultSuccessUrl("/")
+                );
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public LogoutSuccessHandler logoutSuccessHandler() {
+        return new HttpStatusReturningLogoutSuccessHandler();
+    }
+}

--- a/src/main/java/zighang2/zighang/global/config/SwaggerConfig.java
+++ b/src/main/java/zighang2/zighang/global/config/SwaggerConfig.java
@@ -1,0 +1,44 @@
+package zighang2.zighang.global.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+@Configuration
+public class SwaggerConfig {
+    @Value("${server.servlet.context-path:/}")
+    private String contextPath;
+
+    @Bean
+    public OpenAPI Express2API() {
+        Info info = new Info()
+                .title("Express2 API")
+                .description("Express2 API API 명세서")
+                .version("1.0.0");
+
+        String jwtSchemeName = "JWT TOKEN";
+
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+
+        Components components = new Components()
+                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                        .name(jwtSchemeName)
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT"));
+
+        return new OpenAPI()
+                .addServersItem(new Server().url(contextPath))
+                .info(info)
+                .addSecurityItem(securityRequirement)
+                .components(components);
+    }
+}

--- a/src/main/java/zighang2/zighang/global/config/SwaggerConfig.java
+++ b/src/main/java/zighang2/zighang/global/config/SwaggerConfig.java
@@ -18,10 +18,10 @@ public class SwaggerConfig {
     private String contextPath;
 
     @Bean
-    public OpenAPI Express2API() {
+    public OpenAPI express2API() {
         Info info = new Info()
                 .title("Express2 API")
-                .description("Express2 API API 명세서")
+                .description("Express2 API 명세서")
                 .version("1.0.0");
 
         String jwtSchemeName = "JWT TOKEN";

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,0 @@
-spring.application.name=zighang


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #5

## 📝작업 내용

> Swagger 설정과 카카오 로그인을 위한 Spring Security 설정을 했습니다

### 스크린샷 (선택)
<img width="746" height="589" alt="스크린샷 2025-08-26 오후 8 09 08" src="https://github.com/user-attachments/assets/d7b905fb-f6d9-484f-a1e6-5e97518a9bab" />



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - OAuth2 기반 로그인 페이지(/login) 추가 및 로그아웃 후 로그인 페이지로 이동하도록 로그아웃 동작 개선.
  - API 문서 UI 추가로 브라우저에서 엔드포인트 확인 가능; JWT 보안 스키마 명세 포함.
- 작업
  - 보안, OAuth2 클라이언트, API 문서화(UI) 및 관련 테스트 의존성 추가.
  - 민감 설정 파일(application.yml) 버전 관리 제외(.gitignore에 추가).
- 구성
  - 애플리케이션 이름 설정 제거로 기본값 사용.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->