### PR TITLE
[Chore] cicd 워크플로우 작성 (#7)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,6 @@ jobs:
   push_to_registry:
     name: Push to ncp container registry
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,75 @@
+name:  Spring Boot & Gradle CI/CD
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  push_to_registry:
+    name: Push to ncp container registry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to NCP Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ secrets.NCP_CONTAINER_REGISTRY }}
+          username: ${{ secrets.NCP_ACCESS_KEY }}
+          password: ${{ secrets.NCP_SECRET_KEY }}
+
+      - name: make application.yml
+        run: |
+          cd ./src/main/resources
+          touch ./application.yml
+          echo "${{ secrets.APPLICATION }}" > ./application.yml
+        shell: bash
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew clean build -x test
+
+      - name: build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.NCP_CONTAINER_REGISTRY }}/app:latest
+          cache-from: type=registry,ref=${{ secrets.NCP_CONTAINER_REGISTRY }}/app:latest
+          cache-to: type=inline
+          secrets: |
+            GIT_AUTH_TOKEN=${{ secrets.GIT_TOKEN }}
+
+  pull_from_registry:
+    name: Connect server ssh and pull from container registry
+    needs: push_to_registry
+    runs-on: ubuntu-latest
+    steps:
+      - name: connect ssh
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.DEV_HOST }}
+          username: ${{ secrets.DEV_USERNAME }}
+          password: ${{ secrets.DEV_PASSWORD }}
+          port: ${{ secrets.DEV_PORT }}
+          script: |
+            docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/:latest
+            docker stop $(docker ps -a -q)
+            docker rm $(docker ps -a -q)
+            docker run -d -p 8080:8080 --name app ${{ secrets.NCP_CONTAINER_REGISTRY }}/:latest     
+            docker image prune -f

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,8 +49,8 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{ secrets.NCP_CONTAINER_REGISTRY }}/app:latest
-          cache-from: type=registry,ref=${{ secrets.NCP_CONTAINER_REGISTRY }}/app:latest
+          tags: ${{ secrets.NCP_CONTAINER_REGISTRY }}/express2:${{ github.sha }}
+          cache-from: type=registry,ref=${{ secrets.NCP_CONTAINER_REGISTRY }}/express2:${{ github.sha }}
           cache-to: type=inline
           secrets: |
             GIT_AUTH_TOKEN=${{ secrets.GIT_TOKEN }}
@@ -68,8 +68,8 @@ jobs:
           password: ${{ secrets.DEV_PASSWORD }}
           port: ${{ secrets.DEV_PORT }}
           script: |
-            docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/:latest
+            docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/express2:${{ github.sha }}
             docker stop $(docker ps -a -q)
             docker rm $(docker ps -a -q)
-            docker run -d -p 8080:8080 --name app ${{ secrets.NCP_CONTAINER_REGISTRY }}/:latest     
+            docker run -d -p 8080:8080 --name app ${{ secrets.NCP_CONTAINER_REGISTRY }}/express2:${{ github.sha }}   
             docker image prune -f

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,7 @@ jobs:
   push_to_registry:
     name: Push to ncp container registry
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -49,7 +50,8 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{ secrets.NCP_CONTAINER_REGISTRY }}/express2:${{ github.sha }}
+          tags: |
+            ${{ secrets.NCP_CONTAINER_REGISTRY }}/express2:${{ github.sha }}
           cache-from: type=registry,ref=${{ secrets.NCP_CONTAINER_REGISTRY }}/express2:${{ github.sha }}
           cache-to: type=inline
           secrets: |
@@ -68,8 +70,10 @@ jobs:
           password: ${{ secrets.DEV_PASSWORD }}
           port: ${{ secrets.DEV_PORT }}
           script: |
+            set -euo pipefail
+            echo "${{ secrets.NCP_SECRET_KEY }}" | docker login ${{ secrets.NCP_CONTAINER_REGISTRY }} -u "${{ secrets.NCP_ACCESS_KEY }}" --password-stdin
             docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/express2:${{ github.sha }}
-            docker stop $(docker ps -a -q)
-            docker rm $(docker ps -a -q)
-            docker run -d -p 8080:8080 --name app ${{ secrets.NCP_CONTAINER_REGISTRY }}/express2:${{ github.sha }}   
+            docker stop app || true
+            docker rm app || true
+            docker run -d -p 8080:8080 --name app ${{ secrets.NCP_CONTAINER_REGISTRY }}/express2:${{ github.sha }}
             docker image prune -f

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . .
 RUN chmod +x ./gradlew
 RUN ./gradlew clean build -x test
 
-FROM eclipse-temurin:17
+FROM azul/zulu-openjdk-alpine:17-latest
 WORKDIR /app
 COPY --from=builder /app/build/libs/*.jar app.jar
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM openjdk:17-jdk AS builder
 WORKDIR /app
 COPY . .
+RUN chmod +x ./gradlew
 RUN ./gradlew clean build -x test
 
-FROM openjdk:17-jdk
+FROM eclipse-temurin:17
 WORKDIR /app
 COPY --from=builder /app/build/libs/*.jar app.jar
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM openjdk:17-jdk AS builder
 WORKDIR /app
+COPY . .
+RUN ./gradlew clean build -x test
+
+FROM openjdk:17-jdk
+WORKDIR /app
 COPY --from=builder /app/build/libs/*.jar app.jar
 EXPOSE 8080
-
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk AS builder
+FROM azul/zulu-openjdk-alpine:17-latest AS builder
 WORKDIR /app
 COPY . .
 RUN chmod +x ./gradlew

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM openjdk:17-jdk AS builder
+WORKDIR /app
+COPY --from=builder /app/build/libs/*.jar app.jar
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #7

## 📝작업 내용

> 서버 배포 & cicd 워크플로우 작성했습니다
워크플로우 단계는 이렇게 정했습니다.
1. push to registry job
    jdk 17 설정, docker buildx 설정
    NCP Container Registry 로그인
    application 파일 생성
    gradle로 spring boot 빌드
    docker 이미지 빌드 및 푸시
2. pull_from_registry Job

하단에 간단 자동화 흐름 올려두겠습니당

### 스크린샷 (선택)
<img width="603" height="280" alt="image" src="https://github.com/user-attachments/assets/a5982f48-2ef0-49d5-b93e-f6151584551b" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 푸시/PR 시점에 트리거되어 애플리케이션을 빌드하고 컨테이너 이미지를 레지스트리에 푸시한 뒤 원격 호스트로 자동 배포하는 CI/CD 파이프라인을 도입했습니다. 원격 서버 접속을 통한 이미지 교체 및 컨테이너 재시작을 포함합니다.

* **Chores**
  * Java 17 기반의 다단계 컨테이너 빌드 설정을 추가해 표준화된 이미지 생성과 포트 8080에서의 서비스 구동을 지원합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->