### PR TITLE
[Feat] 마이페이지 기능 구현, swagger 수정

### DIFF
--- a/src/main/java/zighang2/zighang/global/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/zighang2/zighang/global/auth/jwt/JwtAuthenticationFilter.java
@@ -32,12 +32,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
 
-        String token = resolveToken(request);
+        String token = jwtProvider.resolveToken(request);
         if(StringUtils.hasText(token) && jwtProvider.validateToken(token,"access")
                 && SecurityContextHolder.getContext().getAuthentication() == null) {
-            String email = jwtProvider.getEmailFromToken(token);
+            Long userId = jwtProvider.getUserIdFromToken(token);
 
-            User user = userRepository.findByEmail(email)
+            User user = userRepository.findById(userId)
                     .orElseThrow(() -> new NotFoundHandler(ErrorStatus.USER_NOT_FOUND));
 
             UserDto userDto = UserDto.of(user);
@@ -51,12 +51,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
-    private String resolveToken(HttpServletRequest request) {
-        String bearerToken = request.getHeader("Authorization");
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-            return bearerToken.substring(7);
-        }
-        return null;
-    }
+
 
 }

--- a/src/main/java/zighang2/zighang/global/auth/jwt/JwtProvider.java
+++ b/src/main/java/zighang2/zighang/global/auth/jwt/JwtProvider.java
@@ -3,11 +3,17 @@ package zighang2.zighang.global.auth.jwt;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import zighang2.zighang.global.auth.UserPrincipal;
 import zighang2.zighang.global.payload.code.status.ErrorStatus;
+import zighang2.zighang.global.payload.exception.GeneralException;
 import zighang2.zighang.global.payload.exception.handler.BadRequestHandler;
+import zighang2.zighang.global.payload.exception.handler.NotFoundHandler;
 import zighang2.zighang.global.service.RedisService;
 import zighang2.zighang.web.domain.user.User;
 import zighang2.zighang.web.dto.TokenResponseDto;
@@ -44,7 +50,7 @@ public class JwtProvider {
         Date now = new Date();
         Date expiration = new Date(now.getTime() + accessTokenExpirationTime);
         return Jwts.builder()
-                .setSubject(user.getEmail())
+                .setSubject(String.valueOf(user.getId()))
                 .claim("role", user.getUserRole().name())
                 .setIssuedAt(now)
                 .setExpiration(expiration)
@@ -57,7 +63,7 @@ public class JwtProvider {
         Date now = new Date();
         Date expiration = new Date(now.getTime() + refreshTokenExpirationTime);
         return Jwts.builder()
-                .setSubject(user.getEmail())
+                .setSubject(String.valueOf(user.getId()))
                 .claim("role", user.getUserRole().name())
                 .setIssuedAt(now)
                 .setExpiration(expiration)
@@ -91,26 +97,24 @@ public class JwtProvider {
         }
     }
 
-    // 토큰에서 사용자 email 추출
-    public String getEmailFromToken(String token) {
-        try {
-            Claims claims = Jwts.parserBuilder()
-                    .setSigningKey(key)
-                    .build()
-                    .parseClaimsJws(token)
-                    .getBody();
-            return claims.getSubject();
-        }catch (ExpiredJwtException e) {
-            throw new BadRequestHandler(ErrorStatus.EXPIRED_TOKEN);
-        } catch (MalformedJwtException e) {
-            throw new BadRequestHandler(ErrorStatus.MALFORMED_TOKEN);
-        } catch (UnsupportedJwtException e) {
-            throw new BadRequestHandler(ErrorStatus.UNSUPPORTED_TOKEN);
-        } catch (IllegalArgumentException e) {
-            throw new BadRequestHandler(ErrorStatus.EMPTY_CLAIMS);
-        } catch (JwtException e) {
-            throw new BadRequestHandler(ErrorStatus.INVALID_TOKEN);
+    public Long getUserIdFromToken(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        return Long.parseLong(claims.getSubject());
+    }
+
+    // 토큰에서 userId 뽑는 메소드
+    public Long getCurrentUserId() {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        if (principal instanceof UserPrincipal userPrincipal) {
+            return userPrincipal.getId();
         }
+
+        throw new NotFoundHandler(ErrorStatus.USER_NOT_FOUND);
     }
 
     // 토큰 만료 확인
@@ -144,5 +148,13 @@ public class JwtProvider {
 
     public Long getExpirationTime(String token) {
         return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().getExpiration().getTime();
+    }
+
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
     }
 }

--- a/src/main/java/zighang2/zighang/global/config/SecurityConfig.java
+++ b/src/main/java/zighang2/zighang/global/config/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/", "/login","/auth/login/kakao/**", "/auth/**", "/auth/refresh-token","/error").permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-resources/**","/swagger-ui/**", "/swagger-ui.html").permitAll()
-                        .requestMatchers("/user").authenticated()
+                        .requestMatchers("/users").authenticated()
                         .anyRequest().permitAll()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/zighang2/zighang/web/controller/UserController.java
+++ b/src/main/java/zighang2/zighang/web/controller/UserController.java
@@ -1,0 +1,20 @@
+package zighang2.zighang.web.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import zighang2.zighang.global.payload.ApiResponse;
+import zighang2.zighang.web.dto.UserDto;
+import zighang2.zighang.web.service.UserService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users")
+public class UserController {
+    private final UserService userService;
+
+    @PatchMapping("")
+    ApiResponse<?> modifyUsersInfo(@RequestBody UserDto.userModifyDto userModifyDto) {
+        return ApiResponse.onSuccess(userService.modifyUserInfo(userModifyDto));
+    }
+}

--- a/src/main/java/zighang2/zighang/web/controller/UserController.java
+++ b/src/main/java/zighang2/zighang/web/controller/UserController.java
@@ -1,7 +1,6 @@
 package zighang2.zighang.web.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import zighang2.zighang.global.payload.ApiResponse;
 import zighang2.zighang.web.dto.UserDto;
@@ -14,7 +13,7 @@ public class UserController {
     private final UserService userService;
 
     @PatchMapping("")
-    ApiResponse<?> modifyUsersInfo(@RequestBody UserDto.userModifyDto userModifyDto) {
+    ApiResponse<?> modifyUsersInfo(@RequestBody UserDto.UserModifyDto userModifyDto) {
         return ApiResponse.onSuccess(userService.modifyUserInfo(userModifyDto));
     }
 }

--- a/src/main/java/zighang2/zighang/web/domain/user/User.java
+++ b/src/main/java/zighang2/zighang/web/domain/user/User.java
@@ -11,6 +11,7 @@ import zighang2.zighang.global.common.BaseEntity;
 @AllArgsConstructor
 public class User extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
     private Long id;
 
     @Setter
@@ -27,5 +28,29 @@ public class User extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private UserRole userRole;
+
+    @Column(length = 50)
+    private String jobGroup;
+
+    @Column(length = 50)
+    private String companySize;
+
+    @Column(length = 50)
+    private String eduation;
+
+    @Column(length = 50)
+    private String workExperience;
+
+    @Column(length = 50)
+    private String receivingEmail;
+
+    public void updateUsersInfo(UserRole userRole, String jobGroup, String companySize, String eduation, String workExperience, String receivingEmail) {
+        if (userRole != null) this.userRole = userRole;
+        if (jobGroup != null) this.jobGroup = jobGroup;
+        if (companySize != null) this.companySize = companySize;
+        if (eduation != null) this.eduation = eduation;
+        if (workExperience != null) this.workExperience = workExperience;
+        if (receivingEmail != null) this.receivingEmail = receivingEmail;
+    }
 
 }

--- a/src/main/java/zighang2/zighang/web/domain/user/User.java
+++ b/src/main/java/zighang2/zighang/web/domain/user/User.java
@@ -36,7 +36,7 @@ public class User extends BaseEntity {
     private String companySize;
 
     @Column(length = 50)
-    private String eduation;
+    private String education;
 
     @Column(length = 50)
     private String workExperience;
@@ -44,13 +44,12 @@ public class User extends BaseEntity {
     @Column(length = 50)
     private String receivingEmail;
 
-    public void updateUsersInfo(UserRole userRole, String jobGroup, String companySize, String eduation, String workExperience, String receivingEmail) {
-        if (userRole != null) this.userRole = userRole;
-        if (jobGroup != null) this.jobGroup = jobGroup;
-        if (companySize != null) this.companySize = companySize;
-        if (eduation != null) this.eduation = eduation;
-        if (workExperience != null) this.workExperience = workExperience;
-        if (receivingEmail != null) this.receivingEmail = receivingEmail;
+    public void updateUsersInfo(String jobGroup, String companySize, String eduation, String workExperience, String receivingEmail) {
+        if (jobGroup != null) this.jobGroup = jobGroup.trim();
+        if (companySize != null) this.companySize = companySize.trim();
+        if (eduation != null) this.education = eduation.trim();
+        if (workExperience != null) this.workExperience = workExperience.trim();
+        if (receivingEmail != null) this.receivingEmail = receivingEmail.trim();
     }
 
 }

--- a/src/main/java/zighang2/zighang/web/dto/UserDto.java
+++ b/src/main/java/zighang2/zighang/web/dto/UserDto.java
@@ -1,5 +1,6 @@
 package zighang2.zighang.web.dto;
 
+import jakarta.persistence.Column;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,6 +15,32 @@ public class UserDto {
     private String email;
     private String nickname;
     private UserRole role;
+
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class userModifyDto {
+        private UserRole userRole;
+        private String jobGroup;
+        private String companySize;
+        private String eduation;
+        private String workExperience;
+        private String receivingEmail;
+
+
+        public UserDto.userModifyDto of(User user) {
+            return userModifyDto.builder()
+                    .companySize(user.getCompanySize())
+                    .userRole(userRole)
+                    .jobGroup(jobGroup)
+                    .eduation(eduation)
+                    .workExperience(workExperience)
+                    .receivingEmail(receivingEmail)
+                    .build();
+
+        }
+    }
 
     public static UserDto of(User user) {
         return UserDto.builder()

--- a/src/main/java/zighang2/zighang/web/dto/UserDto.java
+++ b/src/main/java/zighang2/zighang/web/dto/UserDto.java
@@ -1,15 +1,17 @@
 package zighang2.zighang.web.dto;
 
-import jakarta.persistence.Column;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import zighang2.zighang.web.domain.user.User;
 import zighang2.zighang.web.domain.user.UserRole;
+    import static lombok.AccessLevel.PROTECTED;
 
 @Getter
 @Builder
 @AllArgsConstructor
+@NoArgsConstructor(access = PROTECTED)
 public class UserDto {
     private Long id;
     private String email;
@@ -20,23 +22,21 @@ public class UserDto {
     @Getter
     @Builder
     @AllArgsConstructor
-    public static class userModifyDto {
+    public static class UserModifyDto {
         private UserRole userRole;
         private String jobGroup;
         private String companySize;
-        private String eduation;
+        private String education;
         private String workExperience;
         private String receivingEmail;
 
-
-        public UserDto.userModifyDto of(User user) {
-            return userModifyDto.builder()
+        public UserModifyDto of(User user) {
+            return UserModifyDto.builder()
                     .companySize(user.getCompanySize())
-                    .userRole(userRole)
-                    .jobGroup(jobGroup)
-                    .eduation(eduation)
-                    .workExperience(workExperience)
-                    .receivingEmail(receivingEmail)
+                    .jobGroup(user.getJobGroup())
+                    .education(user.getEducation())
+                    .workExperience(user.getWorkExperience())
+                    .receivingEmail(user.getReceivingEmail())
                     .build();
 
         }

--- a/src/main/java/zighang2/zighang/web/repository/UserRepository.java
+++ b/src/main/java/zighang2/zighang/web/repository/UserRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+
+    Optional<User> findById(Long userId);
 }

--- a/src/main/java/zighang2/zighang/web/repository/UserRepository.java
+++ b/src/main/java/zighang2/zighang/web/repository/UserRepository.java
@@ -9,6 +9,4 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
-
-    Optional<User> findById(Long userId);
 }

--- a/src/main/java/zighang2/zighang/web/service/AuthService.java
+++ b/src/main/java/zighang2/zighang/web/service/AuthService.java
@@ -66,8 +66,9 @@ public class AuthService {
             throw new GeneralException(ErrorStatus.INVALID_TOKEN);
         }
 
-        String email = jwtProvider.getEmailFromToken(token);
-        User user=userRepository.findByEmail(email)
+        Long userId = jwtProvider.getUserIdFromToken(token);
+
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.USER_NOT_FOUND));
 
         String savedToken = redisService.getRefreshToken(user.getId());

--- a/src/main/java/zighang2/zighang/web/service/UserService.java
+++ b/src/main/java/zighang2/zighang/web/service/UserService.java
@@ -16,12 +16,12 @@ public class UserService {
     private final UserRepository userRepository;
     private final JwtProvider jwtProvider;
 
-    public UserDto.userModifyDto modifyUserInfo(UserDto.userModifyDto userModifyDto) {
+    public UserDto.UserModifyDto modifyUserInfo(UserDto.UserModifyDto userModifyDto) {
         Long userId = jwtProvider.getCurrentUserId();
 
         User user = userRepository.findById(userId).orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
-        user.updateUsersInfo(userModifyDto.getUserRole(), userModifyDto.getJobGroup(), userModifyDto.getCompanySize(), userModifyDto.getEduation(), userModifyDto.getReceivingEmail(), userModifyDto.getWorkExperience());
+        user.updateUsersInfo(userModifyDto.getJobGroup(), userModifyDto.getCompanySize(), userModifyDto.getEducation(), userModifyDto.getReceivingEmail(), userModifyDto.getWorkExperience());
         userRepository.save(user);
 
         User updatedUser = userRepository.findById(userId).orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));

--- a/src/main/java/zighang2/zighang/web/service/UserService.java
+++ b/src/main/java/zighang2/zighang/web/service/UserService.java
@@ -1,0 +1,31 @@
+package zighang2.zighang.web.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import zighang2.zighang.global.auth.jwt.JwtProvider;
+import zighang2.zighang.global.payload.code.status.ErrorStatus;
+import zighang2.zighang.global.payload.exception.GeneralException;
+import zighang2.zighang.web.domain.user.User;
+import zighang2.zighang.web.dto.UserDto;
+import zighang2.zighang.web.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final JwtProvider jwtProvider;
+
+    public UserDto.userModifyDto modifyUserInfo(UserDto.userModifyDto userModifyDto) {
+        Long userId = jwtProvider.getCurrentUserId();
+
+        User user = userRepository.findById(userId).orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        user.updateUsersInfo(userModifyDto.getUserRole(), userModifyDto.getJobGroup(), userModifyDto.getCompanySize(), userModifyDto.getEduation(), userModifyDto.getReceivingEmail(), userModifyDto.getWorkExperience());
+        userRepository.save(user);
+
+        User updatedUser = userRepository.findById(userId).orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        return userModifyDto.of(updatedUser);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)
<img width="309" height="164" alt="image" src="https://github.com/user-attachments/assets/f49e5192-abb1-4fc2-b061-377dd4ba62df" />
위의 필드 수정 api만듦

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 사용자 정보 수정 API(PATCH /users) 추가: 직군, 회사 규모, 학력, 경력, 수신 이메일을 업데이트할 수 있습니다.
- 보안/접근 제어
  - /users 경로에 인증이 필요하도록 접근 정책을 정비했습니다.
- 리팩터링
  - 인증 토큰이 사용자 식별을 이메일 대신 사용자 ID 기반으로 처리하도록 개선해 안정성과 일관성을 높였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->