### PR TITLE
[Feat] 카카오 로그아웃 구현 (#9)

### DIFF
--- a/src/main/java/zighang2/zighang/global/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/zighang2/zighang/global/auth/jwt/JwtAuthenticationFilter.java
@@ -38,7 +38,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String token = jwtProvider.resolveToken(request);
 
         if (redisService.isBlackListed(token)){
-            throw new GeneralException(ErrorStatus._UNAUTHORIZED);
+            throw new GeneralException(ErrorStatus.BLOCKED_TOKEN);
         }
 
         if(StringUtils.hasText(token) && jwtProvider.validateToken(token,"access")

--- a/src/main/java/zighang2/zighang/global/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/zighang2/zighang/global/auth/jwt/JwtAuthenticationFilter.java
@@ -13,7 +13,9 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 import zighang2.zighang.global.auth.UserPrincipal;
 import zighang2.zighang.global.payload.code.status.ErrorStatus;
+import zighang2.zighang.global.payload.exception.GeneralException;
 import zighang2.zighang.global.payload.exception.handler.NotFoundHandler;
+import zighang2.zighang.global.service.RedisService;
 import zighang2.zighang.web.domain.user.User;
 import zighang2.zighang.web.dto.UserDto;
 import zighang2.zighang.web.repository.UserRepository;
@@ -26,6 +28,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
+    private final RedisService redisService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -33,6 +36,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     FilterChain filterChain) throws ServletException, IOException {
 
         String token = jwtProvider.resolveToken(request);
+
+        if (redisService.isBlackListed(token)){
+            throw new GeneralException(ErrorStatus._UNAUTHORIZED);
+        }
+
         if(StringUtils.hasText(token) && jwtProvider.validateToken(token,"access")
                 && SecurityContextHolder.getContext().getAuthentication() == null) {
             Long userId = jwtProvider.getUserIdFromToken(token);

--- a/src/main/java/zighang2/zighang/global/payload/code/status/ErrorStatus.java
+++ b/src/main/java/zighang2/zighang/global/payload/code/status/ErrorStatus.java
@@ -31,7 +31,7 @@ public enum ErrorStatus implements BaseErrorCode {
     EMPTY_CLAIMS(HttpStatus.BAD_REQUEST, "TOKEN4003", "클레임이 비어있습니다."),
     EMPTY_TOKEN(HttpStatus.BAD_REQUEST, "TOKEN4004", "비어있는 토큰입니다."),
     TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "TOKEN4040", "토큰을 찾을 수 없습니다."),
-    BLOCKED_TOKEN(HttpStatus.FORBIDDEN, "TOKEN4019", "차단된 사용자의 토큰입니다."),
+    BLOCKED_TOKEN(HttpStatus.FORBIDDEN, "TOKEN4019", "블랙리스트에 등록된 토큰입니다"),
 
     ;
 

--- a/src/main/java/zighang2/zighang/global/payload/code/status/ErrorStatus.java
+++ b/src/main/java/zighang2/zighang/global/payload/code/status/ErrorStatus.java
@@ -31,6 +31,8 @@ public enum ErrorStatus implements BaseErrorCode {
     EMPTY_CLAIMS(HttpStatus.BAD_REQUEST, "TOKEN4003", "클레임이 비어있습니다."),
     EMPTY_TOKEN(HttpStatus.BAD_REQUEST, "TOKEN4004", "비어있는 토큰입니다."),
     TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "TOKEN4040", "토큰을 찾을 수 없습니다."),
+    BLOCKED_TOKEN(HttpStatus.FORBIDDEN, "TOKEN4019", "차단된 사용자의 토큰입니다."),
+
     ;
 
 

--- a/src/main/java/zighang2/zighang/global/service/RedisService.java
+++ b/src/main/java/zighang2/zighang/global/service/RedisService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+
 import java.util.concurrent.TimeUnit;
 
 @Service
@@ -14,6 +15,9 @@ public class RedisService {
 
     @Value("${jwt.token.refresh-expiration-time}")
     private long refreshTokenExpirationTime;
+
+    @Value("${jwt.token.access-expiration-time}")
+    private long accessExpirationTime;
 
     private static final String PREFIX = "REFRESH_TOKEN:";
 
@@ -38,5 +42,13 @@ public class RedisService {
 
     private String getKey(Long userId) {
         return PREFIX + userId;
+    }
+
+    public boolean isBlackListed(String token){
+        return Boolean.TRUE.equals(redisTemplate.hasKey("BLACKLIST:"+token));
+    }
+
+    public void addToBlackList(String token, String reason) {
+        redisTemplate.opsForValue().set("BLACKLIST:" + token, reason, accessExpirationTime, TimeUnit.MILLISECONDS);
     }
 }

--- a/src/main/java/zighang2/zighang/global/service/RedisService.java
+++ b/src/main/java/zighang2/zighang/global/service/RedisService.java
@@ -20,6 +20,7 @@ public class RedisService {
     private long accessExpirationTime;
 
     private static final String PREFIX = "REFRESH_TOKEN:";
+    private static final String BLACKLIST_PREFIX = "BLACKLIST:";
 
     public void setRefreshToken(Long userId, String refreshToken) {
         String key = getKey(userId);
@@ -45,10 +46,10 @@ public class RedisService {
     }
 
     public boolean isBlackListed(String token){
-        return Boolean.TRUE.equals(redisTemplate.hasKey("BLACKLIST:"+token));
+        return Boolean.TRUE.equals(redisTemplate.hasKey(BLACKLIST_PREFIX+token));
     }
 
     public void addToBlackList(String token, String reason) {
-        redisTemplate.opsForValue().set("BLACKLIST:" + token, reason, accessExpirationTime, TimeUnit.MILLISECONDS);
+        redisTemplate.opsForValue().set(BLACKLIST_PREFIX + token, reason, accessExpirationTime, TimeUnit.MILLISECONDS);
     }
 }

--- a/src/main/java/zighang2/zighang/global/service/RedisService.java
+++ b/src/main/java/zighang2/zighang/global/service/RedisService.java
@@ -32,7 +32,7 @@ public class RedisService {
     }
 
     public boolean checkExistsValue(String key) {
-        return redisTemplate.hasKey(key);
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
     }
 
     public void deleteRefreshToken(Long userId) {

--- a/src/main/java/zighang2/zighang/web/controller/AuthController.java
+++ b/src/main/java/zighang2/zighang/web/controller/AuthController.java
@@ -3,6 +3,7 @@ package zighang2.zighang.web.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 import zighang2.zighang.global.auth.jwt.JwtProvider;
 import zighang2.zighang.global.payload.ApiResponse;
@@ -14,18 +15,20 @@ import zighang2.zighang.web.service.AuthService;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth")
+@Slf4j
 public class AuthController {
 
     private final AuthService authService;
     private final JwtProvider jwtProvider;
 
     @PostMapping("/login/kakao")
+    @Operation(summary = "카카오 로그인", description = "인가 코드를 통해 토큰을 발급받는 카카오 로그인 API입니다.")
     public ApiResponse<TokenResponseDto.LoginTokenResponseDto> kakaoLogin(@RequestParam("code") String accessCode) {
         return ApiResponse.onSuccess(authService.oAuthLogin(accessCode));
     }
 
     @GetMapping("/refresh-token")
-    @Operation(summary = "JWT 토큰 재발급 API")
+    @Operation(summary = "토큰 재발급 API", description = "accessToken이 만료된 경우, refreshToken을 통해 재발급 받는 API입니다")
     public ApiResponse<TokenResponseDto.RefreshTokenResponseDto> refreshToken(HttpServletRequest request) {
         String token = request.getHeader("Authorization");
         if (token == null || token.isEmpty()) {
@@ -34,10 +37,14 @@ public class AuthController {
         return ApiResponse.onSuccess(authService.recreateAccessToken(token));
     }
 
-    @PostMapping("sign-out")
+    @PostMapping("/sign-out")
     @Operation(summary = "카카오 로그아웃", description = "카카오 로그아웃을 하는 API입니다.")
     public ApiResponse<String> logout(HttpServletRequest request){
         String token = jwtProvider.resolveToken(request);
+        log.info("logout token: {}", token);
+        if (token == null || token.isEmpty()) {
+            throw new GeneralException(ErrorStatus.TOKEN_NOT_FOUND);
+        }
         authService.logoutUser(token);
         return ApiResponse.onSuccess("Logout successful");
     }

--- a/src/main/java/zighang2/zighang/web/controller/AuthController.java
+++ b/src/main/java/zighang2/zighang/web/controller/AuthController.java
@@ -4,10 +4,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import zighang2.zighang.global.auth.jwt.JwtProvider;
 import zighang2.zighang.global.payload.ApiResponse;
 import zighang2.zighang.global.payload.code.status.ErrorStatus;
 import zighang2.zighang.global.payload.exception.GeneralException;
-import zighang2.zighang.web.dto.KakaoDto;
 import zighang2.zighang.web.dto.TokenResponseDto;
 import zighang2.zighang.web.service.AuthService;
 
@@ -17,6 +17,7 @@ import zighang2.zighang.web.service.AuthService;
 public class AuthController {
 
     private final AuthService authService;
+    private final JwtProvider jwtProvider;
 
     @PostMapping("/login/kakao")
     public ApiResponse<TokenResponseDto.LoginTokenResponseDto> kakaoLogin(@RequestParam("code") String accessCode) {
@@ -31,6 +32,14 @@ public class AuthController {
             throw new GeneralException(ErrorStatus.TOKEN_NOT_FOUND);
         }
         return ApiResponse.onSuccess(authService.recreateAccessToken(token));
+    }
+
+    @PostMapping("sign-out")
+    @Operation(summary = "카카오 로그아웃", description = "카카오 로그아웃을 하는 API입니다.")
+    public ApiResponse<String> logout(HttpServletRequest request){
+        String token = jwtProvider.resolveToken(request);
+        authService.logoutUser(token);
+        return ApiResponse.onSuccess("Logout successful");
     }
 
 }

--- a/src/main/java/zighang2/zighang/web/controller/UserController.java
+++ b/src/main/java/zighang2/zighang/web/controller/UserController.java
@@ -13,7 +13,7 @@ public class UserController {
     private final UserService userService;
 
     @PatchMapping("")
-    ApiResponse<?> modifyUsersInfo(@RequestBody UserDto.UserModifyDto userModifyDto) {
+    ApiResponse<UserDto.UserModifyDto> modifyUsersInfo(@RequestBody UserDto.UserModifyDto userModifyDto) {
         return ApiResponse.onSuccess(userService.modifyUserInfo(userModifyDto));
     }
 }

--- a/src/main/java/zighang2/zighang/web/dto/UserDto.java
+++ b/src/main/java/zighang2/zighang/web/dto/UserDto.java
@@ -23,7 +23,6 @@ public class UserDto {
     @Builder
     @AllArgsConstructor
     public static class UserModifyDto {
-        private UserRole userRole;
         private String jobGroup;
         private String companySize;
         private String education;

--- a/src/main/java/zighang2/zighang/web/service/AuthService.java
+++ b/src/main/java/zighang2/zighang/web/service/AuthService.java
@@ -79,4 +79,11 @@ public class AuthService {
 
         return jwtProvider.recreate(user,token);
     }
+
+    public void logoutUser(String token){
+        Long userId = jwtProvider.getCurrentUserId();
+
+        redisService.addToBlackList(token,"logout");
+        redisService.deleteRefreshToken(userId);
+    }
 }

--- a/src/main/java/zighang2/zighang/web/service/UserService.java
+++ b/src/main/java/zighang2/zighang/web/service/UserService.java
@@ -24,8 +24,6 @@ public class UserService {
         user.updateUsersInfo(userModifyDto.getJobGroup(), userModifyDto.getCompanySize(), userModifyDto.getEducation(), userModifyDto.getReceivingEmail(), userModifyDto.getWorkExperience());
         userRepository.save(user);
 
-        User updatedUser = userRepository.findById(userId).orElseThrow(() -> new NotFoundHandler(ErrorStatus.USER_NOT_FOUND));
-
-        return userModifyDto.of(updatedUser);
+        return userModifyDto.of(user);
     }
 }

--- a/src/main/java/zighang2/zighang/web/service/UserService.java
+++ b/src/main/java/zighang2/zighang/web/service/UserService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import zighang2.zighang.global.auth.jwt.JwtProvider;
 import zighang2.zighang.global.payload.code.status.ErrorStatus;
 import zighang2.zighang.global.payload.exception.GeneralException;
+import zighang2.zighang.global.payload.exception.handler.NotFoundHandler;
 import zighang2.zighang.web.domain.user.User;
 import zighang2.zighang.web.dto.UserDto;
 import zighang2.zighang.web.repository.UserRepository;
@@ -19,12 +20,12 @@ public class UserService {
     public UserDto.UserModifyDto modifyUserInfo(UserDto.UserModifyDto userModifyDto) {
         Long userId = jwtProvider.getCurrentUserId();
 
-        User user = userRepository.findById(userId).orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        User user = userRepository.findById(userId).orElseThrow(() -> new NotFoundHandler(ErrorStatus.USER_NOT_FOUND));
 
         user.updateUsersInfo(userModifyDto.getJobGroup(), userModifyDto.getCompanySize(), userModifyDto.getEducation(), userModifyDto.getReceivingEmail(), userModifyDto.getWorkExperience());
         userRepository.save(user);
 
-        User updatedUser = userRepository.findById(userId).orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        User updatedUser = userRepository.findById(userId).orElseThrow(() -> new NotFoundHandler(ErrorStatus.USER_NOT_FOUND));
 
         return userModifyDto.of(updatedUser);
     }

--- a/src/main/java/zighang2/zighang/web/service/UserService.java
+++ b/src/main/java/zighang2/zighang/web/service/UserService.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import zighang2.zighang.global.auth.jwt.JwtProvider;
 import zighang2.zighang.global.payload.code.status.ErrorStatus;
-import zighang2.zighang.global.payload.exception.GeneralException;
 import zighang2.zighang.global.payload.exception.handler.NotFoundHandler;
 import zighang2.zighang.web.domain.user.User;
 import zighang2.zighang.web.dto.UserDto;


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #9 

## 📝작업 내용

> 카카오 로그아웃 구현했습니다.
<img width="787" height="291" alt="image" src="https://github.com/user-attachments/assets/05fe8a2b-fb23-4a98-9376-2713b7e6cd20" />
<img width="768" height="262" alt="image" src="https://github.com/user-attachments/assets/08dfb632-55f3-41b9-b422-c3d98131a61e" />

로그아웃 후에는 마이페이지 접근 안 되는 거 확인했습니당

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 로그아웃 엔드포인트 추가: POST /auth/sign-out. 로그아웃 시 액세스 토큰을 블랙리스트에 등록하고 리프레시 토큰을 무효화합니다.
  - 블랙리스트 토큰 차단 적용: 블랙리스트에 등록된 토큰 사용 시 즉시 인증이 거부됩니다.
  - 블랙리스트 관련 오류 응답 추가: 차단된 토큰에 대한 명확한 오류 반환이 추가되었습니다.
  - 인증 관련 로그 및 API 문서 개선.

- Refactor
  - 사용자 정보 수정 DTO에서 userRole 필드 제거 및 관련 반환 타입 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->