### PR TITLE
feature: 마이페이지 조회 API (#17)

### DIFF
--- a/src/main/java/zighang2/zighang/web/controller/UserController.java
+++ b/src/main/java/zighang2/zighang/web/controller/UserController.java
@@ -1,5 +1,6 @@
 package zighang2.zighang.web.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import zighang2.zighang.global.payload.ApiResponse;
@@ -13,12 +14,12 @@ public class UserController {
     private final UserService userService;
 
     @PatchMapping("/my-page")
-    public ApiResponse<UserDto.mypageModifyDto> modifyUsersInfo(@RequestBody UserDto.mypageModifyDto mypageDto) {
+    public ApiResponse<UserDto.MypageModifyDto> modifyUsersInfo(@Valid @RequestBody UserDto.MypageModifyDto mypageDto) {
         return ApiResponse.onSuccess(userService.modifyUserInfo(mypageDto));
     }
 
     @GetMapping("/my-page")
-    public ApiResponse<UserDto.myPageDto> getUsersInfo() {
-        return ApiResponse.onSuccess(userService.getUserInfo());
+    public ApiResponse<UserDto.MyPageDto> getUsersInfo() {
+        return ApiResponse.onSuccess(userService.getMypage());
     }
 }

--- a/src/main/java/zighang2/zighang/web/controller/UserController.java
+++ b/src/main/java/zighang2/zighang/web/controller/UserController.java
@@ -12,8 +12,13 @@ import zighang2.zighang.web.service.UserService;
 public class UserController {
     private final UserService userService;
 
-    @PatchMapping("")
-    ApiResponse<UserDto.UserModifyDto> modifyUsersInfo(@RequestBody UserDto.UserModifyDto userModifyDto) {
-        return ApiResponse.onSuccess(userService.modifyUserInfo(userModifyDto));
+    @PatchMapping("/my-page")
+    public ApiResponse<UserDto.mypageModifyDto> modifyUsersInfo(@RequestBody UserDto.mypageModifyDto mypageDto) {
+        return ApiResponse.onSuccess(userService.modifyUserInfo(mypageDto));
+    }
+
+    @GetMapping("/my-page")
+    public ApiResponse<UserDto.myPageDto> getUsersInfo() {
+        return ApiResponse.onSuccess(userService.getUserInfo());
     }
 }

--- a/src/main/java/zighang2/zighang/web/dto/UserDto.java
+++ b/src/main/java/zighang2/zighang/web/dto/UserDto.java
@@ -21,25 +21,26 @@ public class UserDto {
     @Getter
     @Builder
     @AllArgsConstructor
-    public static class myPageDto{
+    public static class MyPageDto {
         private Long id;
         private String email;
         private String name;
-        private UserDto.mypageModifyDto myPageModifyDto;
+        private MypageModifyDto myPageModifyDto;
     }
 
     @Getter
     @Builder
     @AllArgsConstructor
-    public static class mypageModifyDto {
+    @NoArgsConstructor(access = PROTECTED)
+    public static class MypageModifyDto {
         private String jobGroup;
         private String companySize;
         private String education;
         private String workExperience;
         private String receivingEmail;
 
-        public static mypageModifyDto of(User user) {
-            return mypageModifyDto.builder()
+        public static MypageModifyDto of(User user) {
+            return MypageModifyDto.builder()
                     .companySize(user.getCompanySize())
                     .jobGroup(user.getJobGroup())
                     .education(user.getEducation())

--- a/src/main/java/zighang2/zighang/web/dto/UserDto.java
+++ b/src/main/java/zighang2/zighang/web/dto/UserDto.java
@@ -18,19 +18,28 @@ public class UserDto {
     private String nickname;
     private UserRole role;
 
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class myPageDto{
+        private Long id;
+        private String email;
+        private String name;
+        private UserDto.mypageModifyDto myPageModifyDto;
+    }
 
     @Getter
     @Builder
     @AllArgsConstructor
-    public static class UserModifyDto {
+    public static class mypageModifyDto {
         private String jobGroup;
         private String companySize;
         private String education;
         private String workExperience;
         private String receivingEmail;
 
-        public UserModifyDto of(User user) {
-            return UserModifyDto.builder()
+        public static mypageModifyDto of(User user) {
+            return mypageModifyDto.builder()
                     .companySize(user.getCompanySize())
                     .jobGroup(user.getJobGroup())
                     .education(user.getEducation())

--- a/src/main/java/zighang2/zighang/web/service/UserService.java
+++ b/src/main/java/zighang2/zighang/web/service/UserService.java
@@ -16,14 +16,28 @@ public class UserService {
     private final UserRepository userRepository;
     private final JwtProvider jwtProvider;
 
-    public UserDto.UserModifyDto modifyUserInfo(UserDto.UserModifyDto userModifyDto) {
+    public UserDto.mypageModifyDto modifyUserInfo(UserDto.mypageModifyDto mypageModifyDto) {
         Long userId = jwtProvider.getCurrentUserId();
 
         User user = userRepository.findById(userId).orElseThrow(() -> new NotFoundHandler(ErrorStatus.USER_NOT_FOUND));
 
-        user.updateUsersInfo(userModifyDto.getJobGroup(), userModifyDto.getCompanySize(), userModifyDto.getEducation(), userModifyDto.getReceivingEmail(), userModifyDto.getWorkExperience());
+        user.updateUsersInfo(mypageModifyDto.getJobGroup(), mypageModifyDto.getCompanySize(), mypageModifyDto.getEducation(), mypageModifyDto.getReceivingEmail(), mypageModifyDto.getWorkExperience());
         userRepository.save(user);
 
-        return userModifyDto.of(user);
+        return mypageModifyDto.of(user);
+    }
+
+    public UserDto.myPageDto getUserInfo() {
+        Long userId = jwtProvider.getCurrentUserId();
+        User user = userRepository.findById(userId).
+                orElseThrow(() -> new NotFoundHandler(ErrorStatus.USER_NOT_FOUND));
+
+        return UserDto.myPageDto.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .email(user.getEmail())
+                .myPageModifyDto(UserDto.mypageModifyDto.of(user))
+                .build();
+
     }
 }

--- a/src/main/java/zighang2/zighang/web/service/UserService.java
+++ b/src/main/java/zighang2/zighang/web/service/UserService.java
@@ -2,6 +2,7 @@ package zighang2.zighang.web.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import zighang2.zighang.global.auth.jwt.JwtProvider;
 import zighang2.zighang.global.payload.code.status.ErrorStatus;
 import zighang2.zighang.global.payload.exception.handler.NotFoundHandler;
@@ -16,27 +17,33 @@ public class UserService {
     private final UserRepository userRepository;
     private final JwtProvider jwtProvider;
 
-    public UserDto.mypageModifyDto modifyUserInfo(UserDto.mypageModifyDto mypageModifyDto) {
+    @Transactional
+    public UserDto.MypageModifyDto modifyUserInfo(UserDto.MypageModifyDto mypageModifyDto) {
         Long userId = jwtProvider.getCurrentUserId();
 
         User user = userRepository.findById(userId).orElseThrow(() -> new NotFoundHandler(ErrorStatus.USER_NOT_FOUND));
 
-        user.updateUsersInfo(mypageModifyDto.getJobGroup(), mypageModifyDto.getCompanySize(), mypageModifyDto.getEducation(), mypageModifyDto.getReceivingEmail(), mypageModifyDto.getWorkExperience());
+        user.updateUsersInfo(
+                mypageModifyDto.getJobGroup(),
+                mypageModifyDto.getCompanySize(),
+                mypageModifyDto.getEducation(),
+                mypageModifyDto.getWorkExperience(),
+                mypageModifyDto.getReceivingEmail());
         userRepository.save(user);
 
         return mypageModifyDto.of(user);
     }
 
-    public UserDto.myPageDto getUserInfo() {
+    public UserDto.MyPageDto getMypage() {
         Long userId = jwtProvider.getCurrentUserId();
         User user = userRepository.findById(userId).
                 orElseThrow(() -> new NotFoundHandler(ErrorStatus.USER_NOT_FOUND));
 
-        return UserDto.myPageDto.builder()
+        return UserDto.MyPageDto.builder()
                 .id(user.getId())
                 .name(user.getName())
                 .email(user.getEmail())
-                .myPageModifyDto(UserDto.mypageModifyDto.of(user))
+                .myPageModifyDto(UserDto.MypageModifyDto.of(user))
                 .build();
 
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #17 

## 📝작업 내용

> 마이페이지 정보를 조회하는 API 구현했습니다

### 스크린샷 (선택)
<img width="750" height="353" alt="image" src="https://github.com/user-attachments/assets/dc600338-23e1-4e6c-a6fa-99013b2c3cda" />

<img width="737" height="449" alt="image" src="https://github.com/user-attachments/assets/e96524ca-1405-4aa0-8fd2-f7c1791e95f0" />
수정 후에도 잘 오는 거 확인했습니당
## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 현재 사용자 정보를 조회하는 마이페이지 엔드포인트(/users/my-page GET) 추가.
  * 마이페이지 조회에 맞춘 일관된 응답 포맷 제공.

* 변경 사항
  * 프로필 수정 엔드포인트를 /users/my-page(PATCH)로 이전 및 요청/응답 포맷 정비.
  * 프로필 수정 항목 확대: 직무경력(workExperience), 이메일 수신여부(receivingEmail) 포함.
  * 입력 검증(validation) 적용.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->