### PR TITLE
[Feat] 마이프로필 정보 수정 API & 조회 API에 필드 추가 (#14 & #17)

### DIFF
--- a/src/main/java/zighang2/zighang/web/domain/enums/CompanyType.java
+++ b/src/main/java/zighang2/zighang/web/domain/enums/CompanyType.java
@@ -17,7 +17,6 @@ public enum CompanyType {
         this.displayName = displayName;
     }
 
-    @JsonValue
     public String getDisplayName() {
         return displayName;
     }

--- a/src/main/java/zighang2/zighang/web/domain/enums/CompanyType.java
+++ b/src/main/java/zighang2/zighang/web/domain/enums/CompanyType.java
@@ -1,7 +1,5 @@
 package zighang2.zighang.web.domain.enums;
 
-import com.fasterxml.jackson.annotation.JsonValue;
-
 public enum CompanyType {
     MAJOR("대기업"),
     MID_SIZE("중견기업"),

--- a/src/main/java/zighang2/zighang/web/domain/enums/Education.java
+++ b/src/main/java/zighang2/zighang/web/domain/enums/Education.java
@@ -16,7 +16,6 @@ public enum Education {
         this.displayName = displayName;
     }
 
-    @JsonValue
     public String getDisplayName() {
         return displayName;
     }

--- a/src/main/java/zighang2/zighang/web/domain/enums/Education.java
+++ b/src/main/java/zighang2/zighang/web/domain/enums/Education.java
@@ -1,7 +1,5 @@
 package zighang2.zighang.web.domain.enums;
 
-import com.fasterxml.jackson.annotation.JsonValue;
-
 public enum Education {
     IRRELEVANT("무관"),
     HIGH_SCHOOL("고졸"),

--- a/src/main/java/zighang2/zighang/web/domain/enums/JobGroup.java
+++ b/src/main/java/zighang2/zighang/web/domain/enums/JobGroup.java
@@ -36,7 +36,6 @@ public enum JobGroup {
         this.display = display;
     }
 
-    @JsonValue
     public String getDisplay() {
         return display;
     }

--- a/src/main/java/zighang2/zighang/web/domain/enums/JobGroup.java
+++ b/src/main/java/zighang2/zighang/web/domain/enums/JobGroup.java
@@ -1,7 +1,5 @@
 package zighang2.zighang.web.domain.enums;
 
-import com.fasterxml.jackson.annotation.JsonValue;
-
 public enum JobGroup {
     전체("전체"),
     IT_개발("IT/개발"),

--- a/src/main/java/zighang2/zighang/web/domain/enums/JobPosition.java
+++ b/src/main/java/zighang2/zighang/web/domain/enums/JobPosition.java
@@ -1,7 +1,5 @@
 package zighang2.zighang.web.domain.enums;
 
-import com.fasterxml.jackson.annotation.JsonValue;
-
 public enum JobPosition {
     // IT·개발
     서버_백엔드("서버·백엔드"),

--- a/src/main/java/zighang2/zighang/web/domain/enums/JobPosition.java
+++ b/src/main/java/zighang2/zighang/web/domain/enums/JobPosition.java
@@ -368,7 +368,6 @@ public enum JobPosition {
         this.display = display;
     }
 
-    @JsonValue
     public String getDisplay() {
         return display;
     }

--- a/src/main/java/zighang2/zighang/web/domain/enums/RecruitmentType.java
+++ b/src/main/java/zighang2/zighang/web/domain/enums/RecruitmentType.java
@@ -1,7 +1,5 @@
 package zighang2.zighang.web.domain.enums;
 
-import com.fasterxml.jackson.annotation.JsonValue;
-
 public enum RecruitmentType {
     FULL_TIME("정규직"),
     CONTRACT("계약직"),

--- a/src/main/java/zighang2/zighang/web/domain/enums/RecruitmentType.java
+++ b/src/main/java/zighang2/zighang/web/domain/enums/RecruitmentType.java
@@ -17,7 +17,6 @@ public enum RecruitmentType {
         this.displayName = displayName;
     }
 
-    @JsonValue
     public String getDisplayName() {
         return displayName;
     }

--- a/src/main/java/zighang2/zighang/web/domain/user/User.java
+++ b/src/main/java/zighang2/zighang/web/domain/user/User.java
@@ -5,7 +5,6 @@ import lombok.*;
 import zighang2.zighang.global.common.BaseEntity;
 import zighang2.zighang.web.domain.JobRecommend;
 import zighang2.zighang.web.domain.enums.*;
-import zighang2.zighang.web.dto.UserDto;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/zighang2/zighang/web/domain/user/User.java
+++ b/src/main/java/zighang2/zighang/web/domain/user/User.java
@@ -4,10 +4,8 @@ import jakarta.persistence.*;
 import lombok.*;
 import zighang2.zighang.global.common.BaseEntity;
 import zighang2.zighang.web.domain.JobRecommend;
-import zighang2.zighang.web.domain.enums.JobGroup;
-import zighang2.zighang.web.domain.enums.JobPosition;
-import zighang2.zighang.web.domain.enums.Transport;
-import zighang2.zighang.web.domain.enums.UserRole;
+import zighang2.zighang.web.domain.enums.*;
+import zighang2.zighang.web.dto.UserDto;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -53,10 +51,12 @@ public class User extends BaseEntity {
     private JobPosition jobPosition;
 
     @Column(length = 50)
-    private String companySize;
+    @Enumerated(EnumType.STRING)
+    private CompanyType companyType;
 
     @Column(length = 50)
-    private String education;
+    @Enumerated(EnumType.STRING)
+    private Education education;
 
     @Column(length = 50)
     private String workExperience;
@@ -71,11 +71,23 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<JobRecommend> jobRecommendList= new ArrayList<>();
 
-    public void updateUsersInfo(JobGroup jobGroup, String companySize, String eduation, String workExperience, String receivingEmail) {
+    public void updateUsersInfo(JobGroup jobGroup,
+                                JobPosition jobPosition,
+                                CompanyType companyType,
+                                Education education,
+                                String workExperience,
+                                String address,
+                                Transport transport,
+                                Integer maxCommuteMinutes,
+                                String receivingEmail) {
         if (jobGroup != null) this.jobGroup = jobGroup;
-        if (companySize != null) this.companySize = companySize.trim();
-        if (eduation != null) this.education = eduation.trim();
+        if (jobPosition != null) this.jobPosition = jobPosition;
+        if (companyType != null) this.companyType = companyType;
+        if (education != null) this.education = education;
         if (workExperience != null) this.workExperience = workExperience.trim();
+        if (address != null) this.address = address.trim();
+        if (transport != null) this.transport = transport;
+        if (maxCommuteMinutes != null) this.maxCommuteMinutes = maxCommuteMinutes;
         if (receivingEmail != null) this.receivingEmail = receivingEmail.trim();
     }
 

--- a/src/main/java/zighang2/zighang/web/dto/UserDto.java
+++ b/src/main/java/zighang2/zighang/web/dto/UserDto.java
@@ -4,10 +4,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import zighang2.zighang.web.domain.enums.JobGroup;
+import zighang2.zighang.web.domain.enums.*;
 import zighang2.zighang.web.domain.user.User;
-import zighang2.zighang.web.domain.enums.UserRole;
-    import static lombok.AccessLevel.PROTECTED;
+
+import static lombok.AccessLevel.PROTECTED;
 
 @Getter
 @Builder
@@ -35,17 +35,25 @@ public class UserDto {
     @NoArgsConstructor(access = PROTECTED)
     public static class MypageModifyDto {
         private JobGroup jobGroup;
-        private String companySize;
-        private String education;
+        private JobPosition jobPosition;
+        private CompanyType companyType;
+        private Education education;
         private String workExperience;
+        private String address;
+        private Transport transport;
+        private Integer maxCommuteMinutes;
         private String receivingEmail;
 
         public static MypageModifyDto of(User user) {
             return MypageModifyDto.builder()
-                    .companySize(user.getCompanySize())
                     .jobGroup(user.getJobGroup())
+                    .jobPosition(user.getJobPosition())
+                    .companyType(user.getCompanyType())
                     .education(user.getEducation())
                     .workExperience(user.getWorkExperience())
+                    .address(user.getAddress())
+                    .transport(user.getTransport())
+                    .maxCommuteMinutes(user.getMaxCommuteMinutes())
                     .receivingEmail(user.getReceivingEmail())
                     .build();
 

--- a/src/main/java/zighang2/zighang/web/service/UserService.java
+++ b/src/main/java/zighang2/zighang/web/service/UserService.java
@@ -25,13 +25,17 @@ public class UserService {
 
         user.updateUsersInfo(
                 mypageModifyDto.getJobGroup(),
-                mypageModifyDto.getCompanySize(),
+                mypageModifyDto.getJobPosition(),
+                mypageModifyDto.getCompanyType(),
                 mypageModifyDto.getEducation(),
                 mypageModifyDto.getWorkExperience(),
-                mypageModifyDto.getReceivingEmail());
-        userRepository.save(user);
+                mypageModifyDto.getAddress(),
+                mypageModifyDto.getTransport(),
+                mypageModifyDto.getMaxCommuteMinutes(),
+                mypageModifyDto.getReceivingEmail()
+        );
 
-        return mypageModifyDto.of(user);
+        return UserDto.MypageModifyDto.of(user);
     }
 
     public UserDto.MyPageDto getMypage() {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #14, #17 

## 📝작업 내용

> 마이페이지 와프가 수정되면서, 기존에 있던 수정 API에도 필드를 추가했다

### 스크린샷
<img width="783" height="175" alt="image" src="https://github.com/user-attachments/assets/d37bed25-8e0d-4f1b-a052-397880aff73a" />
<img width="744" height="205" alt="image" src="https://github.com/user-attachments/assets/4f89ffbd-4250-4596-87a8-e7cb91d3bbef" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 마이페이지에 직무(그룹/포지션), 회사 유형, 주소, 이동수단, 최대 통근시간 입력을 추가했습니다.
  - 학력과 회사 유형을 선택형 항목으로 지원합니다.
  - 기존 “회사 규모” 항목이 “회사 유형”으로 대체되었습니다.
- Refactor
  - 사용자 정보 수정 흐름을 정리해 저장 안정성을 개선했습니다.
  - API 응답의 선택형 항목 표기를 표준 키값으로 통일해 일관성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->