### PR TITLE
Feature: 공고 상세 조회 api (#31)

### DIFF
--- a/src/main/java/zighang2/zighang/global/payload/code/status/ErrorStatus.java
+++ b/src/main/java/zighang2/zighang/global/payload/code/status/ErrorStatus.java
@@ -51,8 +51,9 @@ public enum ErrorStatus implements BaseErrorCode {
     TMAP_TRANSIT_MAPPING_FAILED(HttpStatus.BAD_REQUEST, "TMAP_2202", "대중교통 요약 응답에서 totalTime을 찾지 못했습니다."),
 
     // JOB 관련 에러 6000
-    JOBGROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "JOBGROUP_6001", "해당하는 직군이 존재하지 않습니다."),
-    JOBPOSITION_NOT_FOUND(HttpStatus.NOT_FOUND, "JOBPOSITION_6002", "해당하는 직무가 존재하지 않습니다."),
+    JOBRECOMMEND_NOT_FOUND(HttpStatus.NOT_FOUND, "JOBRECOMMEND_6001", "해당하는 공고가 존재하지 않습니다."),
+    JOBGROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "JOBGROUP_6002", "해당하는 직군이 존재하지 않습니다."),
+    JOBPOSITION_NOT_FOUND(HttpStatus.NOT_FOUND, "JOBPOSITION_6003", "해당하는 직무가 존재하지 않습니다."),
 
     //COMPANYTYPE 관련 에러 7000
     COMPANY_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "COMPANYTYPE_7001","해당하는 기업 유형이 존재하지 않습니다.")

--- a/src/main/java/zighang2/zighang/web/controller/RecommendController.java
+++ b/src/main/java/zighang2/zighang/web/controller/RecommendController.java
@@ -3,8 +3,10 @@ package zighang2.zighang.web.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import zighang2.zighang.web.dto.JobPostingResponseDto;
 import zighang2.zighang.web.dto.JobRecommendDto;
 import zighang2.zighang.web.service.RecommendService;
 
@@ -21,5 +23,11 @@ public class RecommendController {
     @Operation(summary = "추천공고 6개 조회 API", description = "사용자가 회원가입 후, 결과페이지에서 보여지는 추천 공고 6개를 조회하는 API입니다.")
     public List<JobRecommendDto.JobRecommendResponseDto> get6Recommends(){
         return recommendService.get6Recommends();
+    }
+
+    @GetMapping("/{jobPostingId}")
+    @Operation(summary = "공고 상세 조회 API")
+    public JobPostingResponseDto.JobPostingDetailDto getJobPostingDetail(@PathVariable Long jobPostingId){
+        return recommendService.getJobPostingDetail(jobPostingId);
     }
 }

--- a/src/main/java/zighang2/zighang/web/domain/JobPostingJobPosition.java
+++ b/src/main/java/zighang2/zighang/web/domain/JobPostingJobPosition.java
@@ -2,12 +2,14 @@ package zighang2.zighang.web.domain;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import zighang2.zighang.global.common.BaseEntity;
 
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
+@Getter
 @Table(name = "job_posting_job_position",
         uniqueConstraints = {
                 @UniqueConstraint(columnNames = {"job_position_id", "job_recommend_id"})

--- a/src/main/java/zighang2/zighang/web/domain/JobRecommend.java
+++ b/src/main/java/zighang2/zighang/web/domain/JobRecommend.java
@@ -43,6 +43,9 @@ public class JobRecommend extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Education education;
 
+    @Column(length = 50)
+    private Integer workExperience;
+
     @Enumerated(EnumType.STRING)
     private RecruitmentType recruitmentType;
 

--- a/src/main/java/zighang2/zighang/web/domain/JobRecommend.java
+++ b/src/main/java/zighang2/zighang/web/domain/JobRecommend.java
@@ -43,7 +43,6 @@ public class JobRecommend extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Education education;
 
-    @Column(length = 50)
     private Integer workExperience;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/zighang2/zighang/web/domain/user/User.java
+++ b/src/main/java/zighang2/zighang/web/domain/user/User.java
@@ -48,7 +48,6 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Education education;
 
-    @Column(length = 50)
     private Integer workExperience;
 
     @Column(length = 50)

--- a/src/main/java/zighang2/zighang/web/dto/JobPostingResponseDto.java
+++ b/src/main/java/zighang2/zighang/web/dto/JobPostingResponseDto.java
@@ -1,0 +1,55 @@
+package zighang2.zighang.web.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import zighang2.zighang.web.domain.JobRecommend;
+
+import java.util.List;
+
+public class JobPostingResponseDto {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class JobPostingDetailDto {
+        @Schema(description = "공고 ID", example = "1")
+        private Long jobPostingId;
+        @Schema(description = "공고 제목", example = "백엔드 개발자 구인")
+        private String jobPostingTitle;
+        @Schema(description = "회사명", example = "직행")
+        private String companyName;
+        @Schema(description = "경력",example = "1")
+        private Integer workExperience;
+        @Schema(description = "학력", example = "학력 무관")
+        private String education;
+        @Schema(description = "직무", example = "프론트엔드")
+        private List<String> jobPositions;
+        @Schema(description = "근무 형태", example = "전환형 인턴")
+        private String recruitmentType;
+        @Schema(description = "주소", example = "서울특별시 00구 00대로 123")
+        private String recruitmentAddress;
+        @Schema(description = "공고 이미지")
+        private String content;
+
+        public static JobPostingDetailDto of(JobRecommend jobRecommend){
+            return JobPostingDetailDto.builder()
+                    .jobPostingId(jobRecommend.getId())
+                    .jobPostingTitle(jobRecommend.getTitle())
+                    .companyName(jobRecommend.getCompanyName())
+                    .education(jobRecommend.getEducation().getDisplayName())
+                    .workExperience(jobRecommend.getWorkExperience())
+                    .jobPositions(jobRecommend.getJobPostingJobPositions().stream()
+                            .map(jp->jp.getJobPosition().getJobPositionName().getDisplay())
+                            .toList()
+                    )
+                    .recruitmentType(jobRecommend.getRecruitmentType().getDisplayName())
+                    .recruitmentAddress(jobRecommend.getRecruitmentAddress())
+                    .content(jobRecommend.getContent())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/zighang2/zighang/web/dto/JobPostingResponseDto.java
+++ b/src/main/java/zighang2/zighang/web/dto/JobPostingResponseDto.java
@@ -26,7 +26,7 @@ public class JobPostingResponseDto {
         private Integer workExperience;
         @Schema(description = "학력", example = "학력 무관")
         private String education;
-        @Schema(description = "직무", example = "프론트엔드")
+        @Schema(description = "직무", example = "[프론트엔드, 서버_백엔드]")
         private List<String> jobPositions;
         @Schema(description = "근무 형태", example = "전환형 인턴")
         private String recruitmentType;

--- a/src/main/java/zighang2/zighang/web/service/RecommendService.java
+++ b/src/main/java/zighang2/zighang/web/service/RecommendService.java
@@ -85,7 +85,7 @@ public class RecommendService {
         }
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public JobPostingResponseDto.JobPostingDetailDto getJobPostingDetail(Long jobPostingId){
         JobRecommend jobRecommend = jobRecommendRepository.findById(jobPostingId)
                 .orElseThrow(()-> new NotFoundHandler(ErrorStatus.JOBRECOMMEND_NOT_FOUND));

--- a/src/main/java/zighang2/zighang/web/service/RecommendService.java
+++ b/src/main/java/zighang2/zighang/web/service/RecommendService.java
@@ -2,6 +2,7 @@ package zighang2.zighang.web.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import zighang2.zighang.global.auth.jwt.JwtProvider;
 import zighang2.zighang.global.config.TmapClient;
 import zighang2.zighang.global.payload.code.status.ErrorStatus;
@@ -10,6 +11,7 @@ import zighang2.zighang.global.payload.exception.handler.NotFoundHandler;
 import zighang2.zighang.web.domain.JobRecommend;
 import zighang2.zighang.web.domain.enums.Transport;
 import zighang2.zighang.web.domain.user.User;
+import zighang2.zighang.web.dto.JobPostingResponseDto;
 import zighang2.zighang.web.dto.JobRecommendDto;
 import zighang2.zighang.web.dto.tmap.GeocodePoint;
 import zighang2.zighang.web.repository.JobRecommendRepository;
@@ -81,5 +83,13 @@ public class RecommendService {
         } catch (Exception e) {
             return Optional.empty();
         }
+    }
+
+    @Transactional
+    public JobPostingResponseDto.JobPostingDetailDto getJobPostingDetail(Long jobPostingId){
+        JobRecommend jobRecommend = jobRecommendRepository.findById(jobPostingId)
+                .orElseThrow(()-> new NotFoundHandler(ErrorStatus.JOBRECOMMEND_NOT_FOUND));
+
+        return JobPostingResponseDto.JobPostingDetailDto.of(jobRecommend);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #31 

## 📝작업 내용

> 공고 상세 조회 API 구현했습니다.

### 스크린샷

<img width="751" height="327" alt="image" src="https://github.com/user-attachments/assets/13b58ceb-d07f-4e00-82b9-f9a2aad6c5cb" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 공고 상세 조회 API 추가: 공고 ID로 제목, 회사명, 경력(연차), 학력, 직무 목록, 고용 형태, 근무지, 내용 등 상세 정보를 제공합니다.
- 기타
  - 미존재 공고 조회 시 일관된 404 응답을 제공하도록 에러 상태를 추가/조정했습니다.
  - 공고 데이터에 경력(workExperience) 필드가 포함되어 상세 응답에 노출됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->