### PR TITLE
fix: recruitmentType 변경 (#33)

### DIFF
--- a/src/main/java/zighang2/zighang/web/dto/JobPostingResponseDto.java
+++ b/src/main/java/zighang2/zighang/web/dto/JobPostingResponseDto.java
@@ -26,10 +26,10 @@ public class JobPostingResponseDto {
         private Integer workExperience;
         @Schema(description = "학력", example = "학력 무관")
         private String education;
-        @Schema(description = "직무", example = "[프론트엔드, 서버_백엔드]")
+        @Schema(description = "직무", example = "'['프론트엔드', '서버_백엔드']'")
         private List<String> jobPositions;
-        @Schema(description = "근무 형태", example = "전환형 인턴")
-        private String recruitmentType;
+        @Schema(description = "근무 형태", example = "'['전환형인턴', '정규직']'")
+        private List<String> recruitmentType;
         @Schema(description = "주소", example = "서울특별시 00구 00대로 123")
         private String recruitmentAddress;
         @Schema(description = "공고 이미지")
@@ -46,7 +46,10 @@ public class JobPostingResponseDto {
                             .map(jp->jp.getJobPosition().getJobPositionName().getDisplay())
                             .toList()
                     )
-//                    .recruitmentType(jobRecommend.getRecruitmentType().getDisplayName())
+                    .recruitmentType(jobRecommend.getJobPostingRecruitmentTypes().stream()
+                            .map(jr->jr.getRecruitmentType().getRecruitmentType().getDisplayName())
+                            .toList()
+                    )
                     .recruitmentAddress(jobRecommend.getRecruitmentAddress())
                     .content(jobRecommend.getContent())
                     .build();


### PR DESCRIPTION
## #️⃣연관된 이슈

> pr #33,  #31 

## 📝작업 내용

> pr #33 에서 변경된 엔티티에 맞게, 공고 상세 조회 API를 수정하였다

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 채용공고 상세에서 근무 형태가 다중 선택을 지원합니다. API 응답의 recruitmentType가 문자열에서 문자열 리스트로 변경되어 여러 값이 반환됩니다. 직무 예시도 배열 형태로 일관성 향상.
* 문서
  * Swagger 문서의 근무 형태 및 직무 예시를 배열 형태로 갱신하여 실제 응답과 일치하도록 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->